### PR TITLE
[codex] Fix eight-letter tile layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 
 # Node modules (if any)
 node_modules/
+.worktrees/
+.superpowers/
 
 # OS generated files
 .DS_Store

--- a/docs/superpowers/plans/2026-07-03-eight-letter-layout.md
+++ b/docs/superpowers/plans/2026-07-03-eight-letter-layout.md
@@ -1,0 +1,29 @@
+# Eight-letter Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make eight-letter words use a balanced, pseudo-random three-row layout on portrait phones.
+
+**Architecture:** Move the pure row-count calculation from the inline application script into a small browser/Node-compatible module. Change only the eight-letter fixed distribution from `2 / 2 / 2 / 2` to `3 / 2 / 3`, while preserving the existing segmented positioning algorithm.
+
+**Tech Stack:** Static HTML, vanilla JavaScript, Node.js built-in test runner, service worker.
+
+---
+
+### Task 1: Test the row distribution
+
+**Files:**
+- Create: `layout.js`
+- Create: `test/layout.test.js`
+- Modify: `index.html`
+- Modify: `sw.js`
+
+- [ ] **Step 1: Add a pure `buildPerRowCounts` module with the current eight-letter behavior.**
+- [ ] **Step 2: Add tests requiring eight letters to return `[3, 2, 3]` and nine letters to remain `[3, 3, 3]`.**
+- [ ] **Step 3: Run `node --test test/layout.test.js` and verify the eight-letter assertion fails with actual value `[2, 2, 2, 2]`.**
+- [ ] **Step 4: Change the eight-letter map entry to `[3, 2, 3]`.**
+- [ ] **Step 5: Run `node --test test/layout.test.js` and verify both tests pass.**
+- [ ] **Step 6: Load `layout.js` before the inline application script, remove the duplicate inline helper, and add the module to the service-worker asset list.**
+- [ ] **Step 7: Increment the service-worker cache version so existing installations receive the new asset and layout.**
+- [ ] **Step 8: Run the focused test and the repository's static-site validation checks.**
+- [ ] **Step 9: Inspect the diff, commit the scoped files, push the branch, and open a draft PR.**

--- a/docs/superpowers/specs/2026-07-03-eight-letter-layout-design.md
+++ b/docs/superpowers/specs/2026-07-03-eight-letter-layout-design.md
@@ -1,0 +1,17 @@
+# Eight-letter tile layout
+
+## Problem
+
+The fixed eight-letter row distribution is `2 / 2 / 2 / 2`. On a portrait Google Pixel 8 Pro, the resulting narrow segments leave too little useful horizontal variation, so repeated layouts resemble a static grid. The existing nine-letter `3 / 3 / 3` distribution has the desired balance and randomness.
+
+## Design
+
+Change only the eight-letter entry in the fixed row-count map to `3 / 2 / 3`.
+
+This gives eight letters the same three-row footprint as nine letters. The first and third rows each span three segments. The middle row has two wider segments, distributing its tiles across the screen while allowing greater horizontal random jitter. The existing layout algorithm continues to calculate tile size and apply bounded random horizontal and vertical offsets within each segment.
+
+No behavior changes are intended for other letter counts, tile rendering, letter shuffling, or responsive breakpoints.
+
+## Verification
+
+Add an automated test for the fixed row distributions that fails while eight letters return `2 / 2 / 2 / 2` and passes when they return `3 / 2 / 3`. Preserve the nine-letter `3 / 3 / 3` assertion as a regression reference. Run the complete available test suite after the targeted test passes.

--- a/index.html
+++ b/index.html
@@ -212,6 +212,7 @@
 
     <script src="words.js"></script>
     <script src="letter-tile.js"></script>
+    <script src="layout.js"></script>
     <script>
         const letterInput = document.getElementById('letterInput');
         const repositionButton = document.getElementById('repositionButton');
@@ -257,38 +258,7 @@
         
 
         // New segmented layout helpers
-        const buildPerRowCounts = (n, availW, availH) => {
-            const pipMap = {
-                1: [1],
-                2: [1,1],
-                3: [1,1,1],
-                4: [2,2],
-                5: [2,1,2],
-                6: [2,2,2],
-                7: [2,3,2],
-                8: [2,2,2,2],
-                9: [3,3,3],
-                10: [3,4,3]
-            };
-            if (pipMap[n]) return pipMap[n].slice();
-
-            const aspect = availW / availH;
-            let rows = Math.round(Math.sqrt(n / aspect));
-            rows = Math.max(2, Math.min(6, rows));
-            const base = Math.floor(n / rows);
-            let remainder = n % rows;
-            const perRow = new Array(rows).fill(base);
-            let mid = Math.floor(rows / 2);
-            let spread = 0;
-            while (remainder > 0) {
-                const up = mid - spread;
-                const down = mid + spread + (rows % 2 === 0 ? 1 : 0);
-                if (up >= 0 && remainder > 0) { perRow[up]++; remainder--; }
-                if (down < rows && remainder > 0) { perRow[down]++; remainder--; }
-                spread++;
-            }
-            return perRow;
-        };
+        const { buildPerRowCounts } = AnagramLayout;
 
         const calculateSegmentedLayout = (n, width, height, pad) => {
             const { maxTileSize } = getSpacingConfig();

--- a/layout.js
+++ b/layout.js
@@ -1,0 +1,44 @@
+(function (root, factory) {
+    const layout = factory();
+
+    if (typeof module === 'object' && module.exports) {
+        module.exports = layout;
+    } else {
+        root.AnagramLayout = layout;
+    }
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    const buildPerRowCounts = (n, availW, availH) => {
+        const pipMap = {
+            1: [1],
+            2: [1,1],
+            3: [1,1,1],
+            4: [2,2],
+            5: [2,1,2],
+            6: [2,2,2],
+            7: [2,3,2],
+            8: [3,2,3],
+            9: [3,3,3],
+            10: [3,4,3]
+        };
+        if (pipMap[n]) return pipMap[n].slice();
+
+        const aspect = availW / availH;
+        let rows = Math.round(Math.sqrt(n / aspect));
+        rows = Math.max(2, Math.min(6, rows));
+        const base = Math.floor(n / rows);
+        let remainder = n % rows;
+        const perRow = new Array(rows).fill(base);
+        let mid = Math.floor(rows / 2);
+        let spread = 0;
+        while (remainder > 0) {
+            const up = mid - spread;
+            const down = mid + spread + (rows % 2 === 0 ? 1 : 0);
+            if (up >= 0 && remainder > 0) { perRow[up]++; remainder--; }
+            if (down < rows && remainder > 0) { perRow[down]++; remainder--; }
+            spread++;
+        }
+        return perRow;
+    };
+
+    return { buildPerRowCounts };
+}));

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "anagram-solver-v8";
+const CACHE_NAME = "anagram-solver-v9";
 const TAILWIND_CDN = "https://cdn.tailwindcss.com";
 const ASSETS = [
   // Precache only the assets you need for offline. You can include index.html
@@ -6,6 +6,7 @@ const ASSETS = [
   "./index.html",
   "./words.js",
   "./letter-tile.js",
+  "./layout.js",
   "./manifest.json",
   "./robots.txt",
 ];

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildPerRowCounts } = require('../layout.js');
+
+test('eight letters use a balanced three-row layout', () => {
+    assert.deepEqual(buildPerRowCounts(8, 396, 600), [3, 2, 3]);
+});
+
+test('nine letters retain their three-by-three layout', () => {
+    assert.deepEqual(buildPerRowCounts(9, 396, 600), [3, 3, 3]);
+});


### PR DESCRIPTION
## Summary

- change the eight-letter segment distribution from `2 / 2 / 2 / 2` to `3 / 2 / 3`
- extract the row-count helper into a focused, testable browser module
- update the service-worker asset list and cache version for existing PWA installations

## Why

On portrait devices such as the Google Pixel 8 Pro, four rows of two tiles constrain the available random movement and make eight-letter words look like an almost-static grid. A `3 / 2 / 3` distribution uses the same balanced three-row footprint as the existing nine-letter layout while retaining bounded pseudo-random offsets.

## Validation

- `node --test test/layout.test.js`
- `node --check layout.js`
- `node --check sw.js`
- manifest JSON validation
- staged diff whitespace validation

Visual review remains for the preview deployment, particularly at the Google Pixel 8 Pro viewport.
